### PR TITLE
문자 인증 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,15 +1,27 @@
 module.exports = {
+  env: {
+    es6: true,
+    node: true,
+    jest: true,
+  },
   root: true,
-  extends: '@react-native-community',
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+  ],
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: ['react', 'react-hooks', '@typescript-eslint'],
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
       rules: {
-        '@typescript-eslint/no-shadow': ['error'],
-        '@typescript-eslint/no-unused-vars': ['error'],
         'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': ['error'],
+        '@typescript-eslint/no-shadow': ['error'],
         'no-shadow': 'off',
         'no-undef': 'off',
       },

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -269,7 +269,7 @@ android {
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:30.1.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
-
+    implementation 'com.google.firebase:firebase-auth-ktx'
     implementation fileTree(dir: "libs", include: ["*.jar"])
 
     //noinspection GradleDynamicVersion

--- a/ios/Onecake_FrontEnd.xcodeproj/project.pbxproj
+++ b/ios/Onecake_FrontEnd.xcodeproj/project.pbxproj
@@ -244,8 +244,6 @@
 			dependencies = (
 			);
 			name = Onecake_FrontEnd;
-			packageProductDependencies = (
-			);
 			productName = Onecake_FrontEnd;
 			productReference = 13B07F961A680F5B00A75B9A /* Onecake_FrontEnd.app */;
 			productType = "com.apple.product-type.application";
@@ -276,8 +274,6 @@
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
-			packageReferences = (
-			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,8 +10,16 @@ PODS:
     - React-Core (= 0.68.2)
     - React-jsi (= 0.68.2)
     - ReactCommon/turbomodule/core (= 0.68.2)
+  - Firebase/Auth (8.15.0):
+    - Firebase/CoreOnly
+    - FirebaseAuth (~> 8.15.0)
   - Firebase/CoreOnly (8.15.0):
     - FirebaseCore (= 8.15.0)
+  - FirebaseAuth (8.15.0):
+    - FirebaseCore (~> 8.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
+    - GoogleUtilities/Environment (~> 7.7)
+    - GTMSessionFetcher/Core (~> 1.5)
   - FirebaseCore (8.15.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
@@ -88,10 +96,22 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/AppDelegateSwizzler (7.7.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
   - GoogleUtilities/Environment (7.7.0):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.7.0):
     - GoogleUtilities/Environment
+  - GoogleUtilities/Network (7.7.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (7.7.0)"
+  - GoogleUtilities/Reachability (7.7.0):
+    - GoogleUtilities/Logger
+  - GTMSessionFetcher/Core (1.7.2)
   - libevent (2.1.12)
   - nanopb (2.30908.0):
     - nanopb/decode (= 2.30908.0)
@@ -383,6 +403,10 @@ PODS:
   - RNFBApp (14.11.0):
     - Firebase/CoreOnly (= 8.15.0)
     - React-Core
+  - RNFBAuth (14.11.0):
+    - Firebase/Auth (= 8.15.0)
+    - React-Core
+    - RNFBApp
   - RNGestureHandler (2.4.2):
     - React-Core
   - RNReanimated (2.8.0):
@@ -480,6 +504,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
+  - "RNFBAuth (from `../node_modules/@react-native-firebase/auth`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -490,6 +515,7 @@ SPEC REPOS:
   trunk:
     - CocoaAsyncSocket
     - Firebase
+    - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - Flipper
@@ -504,6 +530,7 @@ SPEC REPOS:
     - fmt
     - GoogleDataTransport
     - GoogleUtilities
+    - GTMSessionFetcher
     - libevent
     - nanopb
     - OpenSSL-Universal
@@ -578,6 +605,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/masked-view"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
+  RNFBAuth:
+    :path: "../node_modules/@react-native-firebase/auth"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
@@ -596,6 +625,7 @@ SPEC CHECKSUMS:
   FBLazyVector: a7a655862f6b09625d11c772296b01cd5164b648
   FBReactNativeSpec: 81ce99032d5b586fddd6a38d450f8595f7e04be4
   Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
+  FirebaseAuth: 3e73bf8abf4fbb40f8b421f361f4cc48ee57388c
   FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
   FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
   Flipper: 26fc4b7382499f1281eb8cb921e5c3ad6de91fe0
@@ -611,6 +641,7 @@ SPEC CHECKSUMS:
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
   GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
+  GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
@@ -643,6 +674,7 @@ SPEC CHECKSUMS:
   ReactCommon: 095366164a276d91ea704ce53cb03825c487a3f2
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNFBApp: b1b5a80a676a07dea17e778bda7c1e8b69b2f5ec
+  RNFBAuth: e28fb7cd1b956086e68233b9ea19fb97c428f86b
   RNGestureHandler: 61628a2c859172551aa2100d3e73d1e57878392f
   RNReanimated: 64573e25e078ae6bec03b891586d50b9ec284393
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@react-native-community/masked-view": "^0.1.11",
         "@react-native-firebase/app": "^14.11.0",
+        "@react-native-firebase/auth": "^14.11.0",
         "@react-navigation/bottom-tabs": "^6.3.1",
         "@react-navigation/drawer": "^6.4.1",
         "@react-navigation/native": "^6.0.10",
@@ -3192,6 +3193,14 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@react-native-firebase/auth": {
+      "version": "14.11.0",
+      "resolved": "https://registry.npmjs.org/@react-native-firebase/auth/-/auth-14.11.0.tgz",
+      "integrity": "sha512-h4JJI3DKKpiVLX+FDiFNprUHquoBkZUZA+bpIZoRGHOr9V8GzcD4IGBs2biWOYYGfEvGZvTVlHXlZOo4rmWEuA==",
+      "peerDependencies": {
+        "@react-native-firebase/app": "14.11.0"
       }
     },
     "node_modules/@react-native/assets": {
@@ -15618,6 +15627,12 @@
         "opencollective-postinstall": "^2.0.1",
         "superstruct": "^0.6.2"
       }
+    },
+    "@react-native-firebase/auth": {
+      "version": "14.11.0",
+      "resolved": "https://registry.npmjs.org/@react-native-firebase/auth/-/auth-14.11.0.tgz",
+      "integrity": "sha512-h4JJI3DKKpiVLX+FDiFNprUHquoBkZUZA+bpIZoRGHOr9V8GzcD4IGBs2biWOYYGfEvGZvTVlHXlZOo4rmWEuA==",
+      "requires": {}
     },
     "@react-native/assets": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-firebase/app": "^14.11.0",
+    "@react-native-firebase/auth": "^14.11.0",
     "@react-navigation/bottom-tabs": "^6.3.1",
     "@react-navigation/drawer": "^6.4.1",
     "@react-navigation/native": "^6.0.10",

--- a/src/screens/MainNavigation.tsx
+++ b/src/screens/MainNavigation.tsx
@@ -8,6 +8,7 @@ import Stores from './Stores';
 import Order from './Order';
 import Contact from './Contact';
 import MyPage from './MyPage';
+import SignUp from './SignUp';
 
 const Tab = createBottomTabNavigator();
 
@@ -15,8 +16,8 @@ const MainNavigation = () => {
   return (
     <Tab.Navigator screenOptions={{headerShown: false}}>
       <Tab.Screen
-        name="홈"
-        component={Home}
+        name="회원가입"
+        component={SignUp}
         options={{
           tabBarIcon: ({color, size}) => (
             <Icon name="home" color={color} size={size} />

--- a/src/screens/SignIn.tsx
+++ b/src/screens/SignIn.tsx
@@ -1,0 +1,14 @@
+import {StyleSheet, Text, View} from 'react-native';
+import React from 'react';
+
+const SignIn = () => {
+  return (
+    <View>
+      <Text>SignIn</Text>
+    </View>
+  );
+};
+
+export default SignIn;
+
+const styles = StyleSheet.create({});

--- a/src/screens/SignUp.tsx
+++ b/src/screens/SignUp.tsx
@@ -1,0 +1,14 @@
+import {StyleSheet, Text, View} from 'react-native';
+import React from 'react';
+
+const SignUp = () => {
+  return (
+    <View>
+      <Text>SignUp</Text>
+    </View>
+  );
+};
+
+export default SignUp;
+
+const styles = StyleSheet.create({});

--- a/src/screens/SignUp.tsx
+++ b/src/screens/SignUp.tsx
@@ -1,11 +1,77 @@
-import {StyleSheet, Text, View} from 'react-native';
-import React from 'react';
+import {Button, StyleSheet, Text, TextInput, View} from 'react-native';
+import React, {useState} from 'react';
+import {SafeAreaProvider} from 'react-native-safe-area-context';
+import auth, {FirebaseAuthTypes} from '@react-native-firebase/auth';
+
+const TEST_PHONE_NUMBER = '+82 010-4183-2998';
 
 const SignUp = () => {
+  const [confirm, setConfirm] =
+    useState<FirebaseAuthTypes.ConfirmationResult>();
+  const [code, setCode] = useState<string>('');
+  const [validatedPhoneAuth, setValidatedPhoneAuth] = useState<boolean>(false);
+  const [phoneNumber, setPhoneNumber] = useState<string>('');
+  const convertPhoneNumber = (phoneNumber: string) => {
+    const tmpNumber = phoneNumber.replace(/[-\s]/gi, '');
+    const prevNum = tmpNumber.substring(0, 3);
+    const nextNum = tmpNumber.substring(4, tmpNumber.length);
+    return prevNum + nextNum;
+  };
+  const confirmCode = async () => {
+    try {
+      await confirm
+        ?.confirm(code)
+        .then(res => {
+          const validatedNumber = res?.user.phoneNumber;
+          validatedNumber === TEST_PHONE_NUMBER
+            ? setValidatedPhoneAuth(true)
+            : setValidatedPhoneAuth(false);
+        })
+        .catch(err => console.log(err));
+    } catch (error) {
+      console.log('Invalid code.');
+    }
+  };
+
+  const signInWithPhoneNumber = async (number: string) => {
+    await auth()
+      .signInWithPhoneNumber(number)
+      .then(res => {
+        setConfirm(res);
+        console.log(res);
+      })
+      .catch(err => console.log(err));
+  };
+
+  if (!confirm) {
+    return (
+      <>
+        <TextInput
+          placeholder="전화번호를 입력해주시라요~ (이렇게 +82 010-4183-2998))"
+          onChangeText={setPhoneNumber}
+        />
+        <Button
+          title="핸드폰 문자인증 기능입니다.! TEST_PHONE_NUMBER로 문자가 갑니다!"
+          onPress={() => signInWithPhoneNumber(TEST_PHONE_NUMBER)}
+        />
+      </>
+    );
+  }
+
   return (
-    <View>
-      <Text>SignUp</Text>
-    </View>
+    <SafeAreaProvider>
+      <TextInput value={code} onChangeText={text => setCode(text)} />
+      <Button
+        title="인증 코드를 입력해주시고 눌러주세요"
+        onPress={() => confirmCode()}
+      />
+      {validatedPhoneAuth ? (
+        <Text>인증 성공~</Text>
+      ) : (
+        <Text>응~ 인증 실패</Text>
+      )}
+      <Text>{convertPhoneNumber(TEST_PHONE_NUMBER)}</Text>
+    </SafeAreaProvider>
   );
 };
 


### PR DESCRIPTION
개요 
- firebase android,ios 모두 세팅했음
- 내일 중으로 이메일 알려주면 firebase에 추가 초대해드림~
- ios는 지금 계정이 없어서 APNs 푸시 알림이 되는지 잘 모르겠어서 일단 안드로이드 먼저 구현함

개발 내용
- MainNavigation의 홈을 회원가입 컴포넌트로 바꾸고 임시 코드를 작성함 
- 문자받은 번호를 입력하면 문자가 날라옴
- 그 문자 코드를 입력하면 인증이 되도록 구현함

스크린샷 
검증 결과는 지금 너무 많이해서 구글한테 정지당해서  못 봄. 내일 직접 해보셔요 ㅎ;
![IMG_2584](https://user-images.githubusercontent.com/54930877/173119792-a16c112b-a54a-4f20-8cce-e0e3a96f02e6.PNG)
<img width="520" alt="image" src="https://user-images.githubusercontent.com/54930877/173119935-0a9c9802-b124-4b0c-b4b6-b277ba830ec2.png">

